### PR TITLE
Add `nightly` and `stable` feature flags to enable compilation on stable Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,13 @@ readme = "README.md"
 keywords = ["no_std", "kernel", "interrupts"]
 license = "Apache-2.0/MIT"
 
+[features]
+default = ["nightly"]
+nightly = ["x86_64/inline_asm"]
+stable = ["x86_64/external_asm"]
+
 [dependencies]
-x86_64 = { version = "0.14.2", default-features = false, features = ["instructions", "inline_asm"] }
+x86_64 = { version = "0.14.2", default-features = false, features = ["instructions"] }
 
 [package.metadata.release]
 no-dev-version = true

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- Add `nightly` and `stable` feature flags to enable compilation on stable Rust ([#1](https://github.com/rust-osdev/pic8259/pull/1))
+
 # 0.10.1 – 2021-05-17
 
 - Update repository link in crate metadata.

--- a/README.md
+++ b/README.md
@@ -66,6 +66,11 @@ do.
 All public PIC interfaces are `unsafe`, because it's really easy to trigger
 undefined behavior by misconfiguring the PIC or using it incorrectly.
 
+## Crate Feature Flags
+
+- `nightly` - Uses features that are only usable on nightly Rust. Enabled by default.
+- `stable` - Enable this feature flag to build this crate on stable Rust. You have to add `default-features = false, features = ["stable"]` to your `Cargo.toml`.
+
 ## Licensing
 
 Licensed under the [Apache License, Version 2.0][LICENSE-APACHE] or the


### PR DESCRIPTION
This commit adds two crate feature flags: `nightly` for the builds on
nightly Rust, and `stable` for the builds on stable Rust.
