### PR TITLE
ChainedPICs requires 1 offset instead of 2.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pic8259"
-version = "0.10.4"
+version = "0.10.3"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 edition = "2018"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pic8259"
-version = "0.10.2"
+version = "0.10.4"
 authors = ["Eric Kidd <git@randomhacks.net>"]
 edition = "2018"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,16 +77,16 @@ pub struct ChainedPics {
 impl ChainedPics {
     /// Create a new interface for the standard PIC1 and PIC2 controllers,
     /// specifying the desired interrupt offsets.
-    pub const unsafe fn new(offset1: u8, offset2: u8) -> ChainedPics {
+    pub const unsafe fn new(primary_offset: u8) -> ChainedPics {
         ChainedPics {
             pics: [
                 Pic {
-                    offset: offset1,
+                    offset: primary_offset,
                     command: Port::new(0x20),
                     data: Port::new(0x21),
                 },
                 Pic {
-                    offset: offset2,
+                    offset: primary_offset + 8,
                     command: Port::new(0xA0),
                     data: Port::new(0xA1),
                 },


### PR DESCRIPTION
The current code requires two offsets when calling `ChainedPics::new`. 

The user of the crate is therefore required to provide 2 offsets when using this crate. 

Example:
`pub const OFFSET_1: u8 = 32;` and
`pub const OFFSET_2: u8 = OFFSET_1 + 8;` 

I believe this puts a little weight on the user which could be abstracted away in the implementation of the `ChainedPics::new`.

With `OFFSET_2`, if the user accidentally uses a number greater than 8 or less than 8, we end up with two undesirable cases
1. Leaving a gap between two PICs in the IDT
2. Overwriting some interrupts of the Primary PIC

By taking only one offset from the user, an offset of the Primary PIC we can compute the next offset inside the `ChainedPics::new` essentially avoiding the issue stated above. 
